### PR TITLE
RNA Star tour fixes

### DIFF
--- a/tour_2b.yaml
+++ b/tour_2b.yaml
@@ -63,10 +63,10 @@ STAR is an ultrafast and sensitive RNA-Seq aligner, that maps sequence reads aga
 Here, we want to align the sequence reads from the control and treated samples, against the provided reference genome.<br /><br />
 Click <b>Next</b> to load it.<br />'
     placement: right
-    textinsert: star
+    textinsert: rna star
     postclick:
       - >-
-        a[href$="/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fsarahinraauzeville%2Fstar%2Fsm_star_single_V2%2F1.0.0"]
+        a[href$="/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fiuc%2Frgrnastar%2Frna_star%2F2.5.2b-2"]
 
   - title: '<b>Map sequences against a reference genome</b>'
     element: '#right'

--- a/tour_2b.yaml
+++ b/tour_2b.yaml
@@ -70,13 +70,13 @@ Click <b>Next</b> to load it.<br />'
 
   - title: '<b>Map sequences against a reference genome</b>'
     element: '#right'
-    content: 'In section <b>Paired or single reads</b>, chose <b>Single reads</b>. Then, in section <b>Your single read RNA-Seq FASTQ file</b>, click on the <b>Multiple datasets</b> icon, and select all control and treated samples.<br /><br />
+    content: 'In section <b>Single-end or paired-end reads</b>, chose <b>Single-end</b>. Then, in section <b>RNA-Seq FASTQ/FASTA file</b>, click on the <b>Multiple datasets</b> icon, and select all control and treated samples.<br /><br />
 Click <b>Next</b> to overview further parametrisation options.<br />'
     placement: left
 
   - title: '<b>Map sequences against a reference genome</b>'
     element: '#right'
-    content: 'In section <b>Genotoul reference genome or your own fasta file</b>, select <b>Your own fasta file</b>, and specify the uploaded reference genome.<br />
+    content: 'In section <b>Custom or built-in reference genome</b>, select <b>Use reference genome from history and create temporary index</b>, then in section <b>Select a reference genome</b>, specify the uploaded reference genome.<br />
 If the reference genome does not appear in the box, then you need to first convert it to the correct format. In this case:<br />
 - Click on the pencil icon of the reference genome entry in your history<br />
 - Select the <b>Datatype</b> tab<br />
@@ -88,7 +88,7 @@ Click <b>Next</b> to overview further parametrisation options.<br />'
 
   - title: '<b>Map sequences against a reference genome</b>'
     element: '#right'
-    content: 'In section <b>Your own GTF file</b>, select the gene feature file GFF entry from your history.<br />
+    content: 'In section <b>Gene model (gff3,gtf) file for splice junctions</b>, select the gene feature file GFF entry from your history.<br />
 If the gene feature file does not appear in the box, then you need to first convert it to the correct format. In this case:<br />
 - Click on the pencil icon of the gene feature entry in your history<br />
 - Select the <b>Datatype</b> tab<br />


### PR DESCRIPTION
- fixed loading the tool in the interface (a different string was given to the tool search bar)
- fixed the label dascriptions (label captions changed during the last build, and the tour referred to the old ones)