### PR TITLE
renamed tours to be more human readable

### DIFF
--- a/tour_1a.yaml
+++ b/tour_1a.yaml
@@ -1,7 +1,7 @@
 id: tour-1a
-name: Tour 1a
+name: 'Data preprocessing'
 description: Quality control and data preprocessing with FastQC and Trim Galore!
-title_default: Tour 1a
+title_default: 'Data preprocessing'
 steps:
   - title: '<b>Outline</b>'
     element: ''

--- a/tour_1b.yaml
+++ b/tour_1b.yaml
@@ -1,7 +1,7 @@
 id: tour-1b
-name: Tour 1b
+name: 'Data preprocessing'
 description: Quality control and data preprocessing with FastQC and Trimmomatic
-title_default: Tour 1b
+title_default: 'Data preprocessing'
 steps:
   - title: '<b>Outline</b>'
     element: ''

--- a/tour_1c.yaml
+++ b/tour_1c.yaml
@@ -1,7 +1,7 @@
 id: tour-1c
-name: Tour 1c
+name: 'Data preprocessing'
 description: Quality control and data preprocessing with FastQC and Cutadapt
-title_default: Tour 1c
+title_default: 'Data preprocessing'
 steps:
   - title: '<b>Outline</b>'
     element: ''

--- a/tour_2a.yaml
+++ b/tour_2a.yaml
@@ -1,7 +1,7 @@
 id: tour-2a
-name: Tour 2a
+name: 'Mapping'
 description: Alignment of sequence reads against a reference genome using HISAT2
-title_default: Tour 2a
+title_default: 'Mapping'
 steps:
   - title: '<b>Outline</b>'
     element: ''

--- a/tour_2b.yaml
+++ b/tour_2b.yaml
@@ -1,7 +1,7 @@
 id: tour-2b
-name: Tour 2b
+name: 'Mapping'
 description: Alignment of sequence reads against a reference genome using STAR
-title_default: Tour 2b
+title_default: 'Mapping'
 steps:
   - title: '<b>Outline</b>'
     element: ''

--- a/tour_3a.yaml
+++ b/tour_3a.yaml
@@ -1,7 +1,7 @@
 id: tour-3a
-name: Tour 3a
+name: 'Differential gene expression'
 description: Differential gene expression analysis using featureCounts and DESeq2
-title_default: Tour 3a
+title_default: 'Differential gene expression'
 steps:
   - title: '<b>Outline</b>'
     element: ''

--- a/tour_3b.yaml
+++ b/tour_3b.yaml
@@ -1,7 +1,7 @@
 id: tour-3b
-name: Tour 3b
+name: 'Differential gene expression'
 description: Differntial gene expression analysis using HTSeq-Count and DESeq2.
-title_default: Tour 3b
+title_default: 'Differential gene expression'
 steps:
   - title: '<b>Outline</b>'
     element: ''


### PR DESCRIPTION
The tour list looked like:
`Tour 1a - Quality control and data preprocessing with FastQC and Trim Galore!`
`Tour 2a - Alignment of sequence reads against a reference genome using HISAT2`
`Tour 3a - Differential gene expression analysis using featureCounts and DESeq2`
`...`

With the current modifications, the tour list looks like:
`Data preprocessing - Quality control and data preprocessing with FastQC and Trim Galore!`
`Mapping - Alignment of sequence reads against a reference genome using HISAT2`
`Differential gene expression - Differential gene expression analysis using featureCounts and DESeq2`
`...`